### PR TITLE
Package search fixes for empty-ish datasets and fast path

### DIFF
--- a/ckanext/rvr/actions.py
+++ b/ckanext/rvr/actions.py
@@ -305,13 +305,14 @@ def package_search(context, data_dict):
     """
     # Get dateranges and requested pagination parameters
     dateranges = data_dict.pop("dateranges", {})
+    dateranges_active = (dateranges and any(all(d['params']) for d in dateranges.values()))
     data_dict.pop("date_filters", {})
     items_per_page = int(data_dict.pop("rows", 20))
     start = int(data_dict.pop("start", 0))
 
     # OPTIMIZATION: If no dateranges specified, use default rows/start
     # instead of forcing 1000 rows and pagination through entire dataset
-    if not dateranges:
+    if not dateranges_active:
         data_dict["rows"] = items_per_page
         data_dict["start"] = start
     else:
@@ -482,7 +483,7 @@ def package_search(context, data_dict):
             return scanned_package_count, removed_packages_count, current_facets
 
         # OPTIMIZATION: Only run expensive daterange filtering if dateranges exist
-        if dateranges:
+        if dateranges_active:
             scanned_packages_count = 0
             removed_packages_count = 0
             facets = {}
@@ -530,7 +531,6 @@ def package_search(context, data_dict):
                             res["format"] = helpers.map_format(res["format"])
 
                         results.append(package_dict)
-                        results.append(package_dict)
                     else:
                         log.error(
                             "No package_dict is coming from solr for package id %s",
@@ -542,7 +542,7 @@ def package_search(context, data_dict):
         # For daterange filtering, results contains the full filtered set — paginate with Python slice.
         # For the fast path (no dateranges), Solr already handled pagination via rows/start,
         # so results already contains exactly the current page items.
-        if dateranges:
+        if dateranges_active:
             paginated_results = results[start : start + items_per_page]
         else:
             paginated_results = results

--- a/ckanext/rvr/actions.py
+++ b/ckanext/rvr/actions.py
@@ -67,9 +67,10 @@ def get_package_field(field, package):
     if package.get(field, ""):
         value = package[field]
     else:
-        for item in package["extras"]:
-            if item.get("key", "") == field:
-                value = item["value"]
+        if "extras" in package:
+            for item in package["extras"]:
+                if item.get("key", "") == field:
+                    value = item["value"]
     return value
 
 


### PR DESCRIPTION
- Fix 1: Manually created minimal test datasets sometimes don't contain any `extras` which will make `get_package_field` throw an error when try to search through it. Added a safeguard for that.
- Fix 2: This is pretty much what I posted in [this comment](https://github.com/datopian/client-metropole-ruhr-shared/issues/81#issuecomment-4048638552): Because the `dateranges` variable is always filled with *some* value when using the search page, the fast path is never taken (only when visiting the main page, which is a bit limited). This change checks if any dateranges have actually been set. This improves the performance of searches without date filtering (which I assume most users do) from around 6 to 2 seconds. Also fixed a doubled line that resulted in search results being duplicated.